### PR TITLE
Fix and refactor AlbumPager video playback

### DIFF
--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -336,8 +336,10 @@ public class AlbumPager extends BaseSaveActivity {
                                                 if (SettingValues.oldSwipeMode && position > 0) {
                                                     adjustedPosition = position - 1;
                                                 }
+                                                FragmentManager fm = getSupportFragmentManager();
                                                 for (int i = 0; i < adapter.getCount(); i++) {
-                                                    Fragment frag = ((AlbumViewPagerAdapter)adapter).getFragment(i);
+                                                    String tag = "android:switcher:" + R.id.images_horizontal + ":" + i;
+                                                    Fragment frag = fm.findFragmentByTag(tag);
                                                     if (frag instanceof Gif) {
                                                         ((Gif)frag).setPlaybackActive(i == adjustedPosition);
                                                     }

--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -428,7 +428,7 @@ public class AlbumPager extends BaseSaveActivity {
                     ((ExoVideoView) gif).play();
                     gif.setVisibility(View.VISIBLE);
                 } else {
-                    ((ExoVideoView) gif).pause();
+                    ((ExoVideoView) gif).stop(); // Stop and release resources
                     gif.setVisibility(View.GONE);
                 }
             }

--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -837,7 +837,7 @@ public class AlbumPager extends BaseSaveActivity {
 
         @Override
         public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(Bundle);
+            super.onCreate(savedInstanceState);
             Bundle bundle = this.getArguments();
             i = bundle.getInt("page", 0);
         }

--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -339,7 +339,7 @@ public class AlbumPager extends BaseSaveActivity {
                                                 for (int i = 0; i < adapter.getCount(); i++) {
                                                     Fragment frag = ((AlbumViewPagerAdapter)adapter).getFragment(i);
                                                     if (frag instanceof Gif) {
-                                                        ((Gif)frag).setPlaybackActive(i == position || i == adjustedPosition);
+                                                        ((Gif)frag).setPlaybackActive(i == adjustedPosition);
                                                     }
                                                 }
                                             }

--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -14,7 +14,6 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -366,7 +365,6 @@ public class AlbumPager extends BaseSaveActivity {
     }
 
     private class AlbumViewPagerAdapter extends FragmentStatePagerAdapter {
-        private final List<Fragment> fragmentRefs = new ArrayList<>();
         AlbumViewPagerAdapter(FragmentManager m) {
             super(m, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         }
@@ -376,9 +374,7 @@ public class AlbumPager extends BaseSaveActivity {
         public Fragment getItem(int i) {
             if (SettingValues.oldSwipeMode) {
                 if (i == 0) {
-                    Fragment blank = new BlankFragment();
-                    fragmentRefs.add(blank);
-                    return blank;
+                    return new BlankFragment();
                 }
                 i--;
             }
@@ -392,13 +388,7 @@ public class AlbumPager extends BaseSaveActivity {
             Bundle args = new Bundle();
             args.putInt("page", i);
             f.setArguments(args);
-            fragmentRefs.add(f);
             return f;
-        }
-
-        public Fragment getFragment(int pos) {
-            if (pos >= 0 && pos < fragmentRefs.size()) return fragmentRefs.get(pos);
-            return null;
         }
 
         @Override


### PR DESCRIPTION
- Fixed #227
- Fixed #226
- Ensured only visible fragment plays media
- Stopped playback cleanly to prevent leaks/black screens
- Used reliable fragment retrieval with tags
- Removed dead code and simplified logic