### PR TITLE
Improve video controls & media saving

### DIFF
--- a/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/AlbumPager.java
@@ -613,7 +613,7 @@ public class AlbumPager extends BaseSaveActivity {
         b.sheet(2, external, getString(R.string.open_externally));
         b.sheet(5, share, getString(R.string.submission_link_share));
         if (!isGif) b.sheet(3, image, getString(R.string.share_image));
-        b.sheet(4, save, getString(R.string.submission_save_image));
+        b.sheet(4, save, getString(isGif ? R.string.submission_save_mp4 : R.string.submission_save_image));
         b.listener(
                 new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -193,7 +193,7 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
             } catch (MalformedURLException e) {
                 e.printStackTrace();
             }
-            b.sheet(6, file, getString(R.string.mediaview_save, type));
+
         }
         if (contentUrl.contains("v.redd.it")) {
             b.sheet(15, thread, "View video thread");

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -685,6 +685,28 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                             activeGifDrawable.start();
                             didLoadGif = true; // Mark that a GIF was successfully loaded this way
                             fileLoc = gifFile.getAbsolutePath(); // Potentially for cleanup, though this might need review
+
+                            // Add OnClickListener for directGifViewer (direct GIFs)
+                            directGifViewer.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    // Simulate a tap in the bottom quarter of the screen to ensure it passes the thresholdY check
+                                    int screenHeight = getResources().getDisplayMetrics().heightPixels;
+                                    float simulatedTapY = screenHeight * 0.8f; // 80% down the screen
+
+                                    MotionEvent motionEvent = MotionEvent.obtain(
+                                            SystemClock.uptimeMillis(),
+                                            SystemClock.uptimeMillis() + 100,
+                                            MotionEvent.ACTION_UP,
+                                            0,
+                                            simulatedTapY,
+                                            0
+                                    );
+                                    onSingleTap(motionEvent);
+                                    motionEvent.recycle();
+                                }
+                            });
+
                         } else {
                             Log.e(TAG, "Failed to decode direct GIF: " + gifUrl);
                             Toast.makeText(MediaView.this, "Failed to load GIF.", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -88,7 +88,7 @@ import me.edgan.redditslide.util.GifDrawable;
 import androidx.annotation.NonNull;
 
 /** Created by ccrama on 3/5/2015. */
-public class MediaView extends BaseSaveActivity {
+public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingleTapListener {
     public static final String EXTRA_URL = "url";
     public static final String SUBREDDIT = "sub";
     public static final String ADAPTER_POSITION = "adapter_position";
@@ -437,21 +437,7 @@ public class MediaView extends BaseSaveActivity {
                                 }
                             }
                         });
-        findViewById(R.id.submission_image)
-                .setOnClickListener(
-                        new View.OnClickListener() {
-
-                            @Override
-                            public void onClick(View v2) {
-                                if (findViewById(R.id.gifheader).getVisibility() == View.GONE) {
-                                    AnimatorUtil.animateIn(findViewById(R.id.gifheader), 56);
-                                    AnimatorUtil.fadeOut(findViewById(R.id.black));
-                                    getWindow().getDecorView().setSystemUiVisibility(0);
-                                } else {
-                                    finish();
-                                }
-                            }
-                        });
+        // Removed findViewById(R.id.submission_image).setOnClickListener(...) as ExoVideoView's OnSingleTapListener will handle it
     }
 
     @Override
@@ -706,18 +692,8 @@ public class MediaView extends BaseSaveActivity {
             if (directGifViewer != null) directGifViewer.setVisibility(View.GONE); // Hide our direct ImageViewer
             videoView = (ExoVideoView) findViewById(R.id.gif);
             videoView.setVisibility(View.VISIBLE); // Ensure ExoVideoView is visible
+            videoView.setOnSingleTapListener(this); // Set the single tap listener
 
-            findViewById(R.id.black)
-                    .setOnClickListener(
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View v) {
-                                    if (findViewById(R.id.gifheader).getVisibility() == View.GONE) {
-                                        AnimatorUtil.animateIn(findViewById(R.id.gifheader), 56);
-                                        AnimatorUtil.fadeOut(findViewById(R.id.black));
-                                    }
-                                }
-                            });
             videoView.clearFocus();
             findViewById(R.id.gifarea).setVisibility(View.VISIBLE);
             findViewById(R.id.submission_image).setVisibility(View.GONE);
@@ -748,46 +724,6 @@ public class MediaView extends BaseSaveActivity {
             this.gif.execute(gifUrl); // Use the formatted gifUrl
         }
 
-        // Common setup for both paths (direct GIF or ExoVideoView GIF)
-        videoView = (ExoVideoView) findViewById(R.id.gif);
-        findViewById(R.id.black)
-                .setOnClickListener(
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                if (findViewById(R.id.gifheader).getVisibility() == View.GONE) {
-                                    AnimatorUtil.animateIn(findViewById(R.id.gifheader), 56);
-                                    AnimatorUtil.fadeOut(findViewById(R.id.black));
-                                }
-                            }
-                        });
-        videoView.clearFocus();
-        findViewById(R.id.gifarea).setVisibility(View.VISIBLE);
-        findViewById(R.id.submission_image).setVisibility(View.GONE);
-        final ProgressBar loader = (ProgressBar) findViewById(R.id.gifprogress);
-        findViewById(R.id.progress).setVisibility(View.GONE);
-        gif =
-                new GifUtils.AsyncLoadGif(
-                        this,
-                        videoView,
-                        loader,
-                        findViewById(R.id.placeholder),
-                        true,
-                        true,
-                        ((TextView) findViewById(R.id.size)),
-                        subreddit,
-                        submissionTitle);
-        videoView.attachMuteButton((ImageView) findViewById(R.id.mute));
-        videoView.attachHqButton((ImageView) findViewById(R.id.hq));
-        gif.execute(dat);
-        findViewById(R.id.more)
-                .setOnClickListener(
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                showBottomSheetImage();
-                            }
-                        });
     }
 
     public void doLoadImgur(String url) {
@@ -1306,6 +1242,25 @@ public class MediaView extends BaseSaveActivity {
 
     private void showErrorDialog() {
         runOnUiThread(() -> DialogUtil.showErrorDialog(MediaView.this));
+    }
+
+    @Override
+    public void onSingleTap() {
+        // This is the logic to toggle gifheader visibility
+        View gifHeader = findViewById(R.id.gifheader);
+        View blackOverlay = findViewById(R.id.black);
+
+        if (gifHeader != null && blackOverlay != null) {
+            if (gifHeader.getVisibility() == View.GONE) {
+                AnimatorUtil.animateIn(gifHeader, 56);
+                AnimatorUtil.fadeOut(blackOverlay);
+                getWindow().getDecorView().setSystemUiVisibility(0);
+            } else {
+                AnimatorUtil.animateOut(gifHeader);
+                AnimatorUtil.fadeIn(blackOverlay);
+                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -26,6 +26,8 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import android.view.MotionEvent;
+
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
@@ -1245,20 +1247,43 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
     }
 
     @Override
-    public void onSingleTap() {
-        // This is the logic to toggle gifheader visibility
-        View gifHeader = findViewById(R.id.gifheader);
-        View blackOverlay = findViewById(R.id.black);
+    public void onSingleTap(MotionEvent event) {
+        // Get screen height and the Y-coordinate of the tap
+        int screenHeight = getResources().getDisplayMetrics().heightPixels;
+        float tapY = event.getRawY(); // Use getRawY for screen coordinates
 
-        if (gifHeader != null && blackOverlay != null) {
-            if (gifHeader.getVisibility() == View.GONE) {
-                AnimatorUtil.animateIn(gifHeader, 56);
-                AnimatorUtil.fadeOut(blackOverlay);
-                getWindow().getDecorView().setSystemUiVisibility(0);
-            } else {
-                AnimatorUtil.animateOut(gifHeader);
-                AnimatorUtil.fadeIn(blackOverlay);
-                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
+        // Get the bottom controls (gifheader) view
+        View gifHeader = findViewById(R.id.gifheader);
+
+        // Determine the threshold for the bottom portion.
+        // A reasonable threshold could be the top of the gifheader, or a fixed percentage of the screen height.
+        // Let's try using the top of the gifheader if it's visible, otherwise a fixed percentage (e.g., bottom 25%).
+        int thresholdY;
+        if (gifHeader != null && gifHeader.getVisibility() == View.VISIBLE) {
+            // If controls are visible, use their top as the threshold
+            int[] location = new int[2];
+            gifHeader.getLocationOnScreen(location);
+            thresholdY = location[1]; // Y-coordinate of the top of gifHeader
+        } else {
+            // If controls are hidden, use a fixed percentage from the bottom
+            thresholdY = (int) (screenHeight * 0.75); // Example: bottom 25% of the screen
+        }
+
+        // Only toggle if the tap occurred in the bottom region
+        if (tapY >= thresholdY) {
+            // Existing toggle logic
+            View blackOverlay = findViewById(R.id.black);
+
+            if (gifHeader != null && blackOverlay != null) {
+                if (gifHeader.getVisibility() == View.GONE) {
+                    AnimatorUtil.animateIn(gifHeader, 56);
+                    AnimatorUtil.fadeOut(blackOverlay);
+                    getWindow().getDecorView().setSystemUiVisibility(0);
+                } else {
+                    AnimatorUtil.animateOut(gifHeader);
+                    AnimatorUtil.fadeIn(blackOverlay);
+                    getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
+                }
             }
         }
     }

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -176,7 +176,7 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
         b.sheet(5, share, getString(R.string.submission_link_share));
 
         if (!isGif) b.sheet(3, image, getString(R.string.share_image));
-        b.sheet(4, save, "Save " + (isGif ? "MP4" : "image"));
+        b.sheet(4, save, getString(isGif ? R.string.submission_save_mp4 : R.string.submission_save_image));
         Drawable folder = getResources().getDrawable(R.drawable.ic_folder);
         if (isGif
                 && !contentUrl.contains(".mp4")

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -757,8 +757,7 @@ public class MediaView extends BaseSaveActivity {
                             public void onClick(View v) {
                                 if (findViewById(R.id.gifheader).getVisibility() == View.GONE) {
                                     AnimatorUtil.animateIn(findViewById(R.id.gifheader), 56);
-                                    View blackOverlay = findViewById(R.id.black);
-                                    AnimatorUtil.fadeOut(blackOverlay, () -> blackOverlay.setVisibility(View.GONE));
+                                    AnimatorUtil.fadeOut(findViewById(R.id.black));
                                 }
                             }
                         });

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -439,7 +439,6 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                                 }
                             }
                         });
-        // Removed findViewById(R.id.submission_image).setOnClickListener(...) as ExoVideoView's OnSingleTapListener will handle it
     }
 
     @Override
@@ -1248,30 +1247,21 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
 
     @Override
     public boolean onSingleTap(MotionEvent event) {
-        // Get screen height and the Y-coordinate of the tap
         int screenHeight = getResources().getDisplayMetrics().heightPixels;
-        float tapY = event.getRawY(); // Use getRawY for screen coordinates
+        float tapY = event.getRawY();
 
-        // Get the bottom controls (gifheader) view
         View gifHeader = findViewById(R.id.gifheader);
 
-        // Determine the threshold for the bottom portion.
-        // A reasonable threshold could be the top of the gifheader, or a fixed percentage of the screen height.
-        // Let's try using the top of the gifheader if it's visible, otherwise a fixed percentage (e.g., bottom 25%).
         int thresholdY;
         if (gifHeader != null && gifHeader.getVisibility() == View.VISIBLE) {
-            // If controls are visible, use their top as the threshold
             int[] location = new int[2];
             gifHeader.getLocationOnScreen(location);
-            thresholdY = location[1]; // Y-coordinate of the top of gifHeader
+            thresholdY = location[1];
         } else {
-            // If controls are hidden, use a fixed percentage from the bottom
-            thresholdY = (int) (screenHeight * 0.75); // Example: bottom 25% of the screen
+            thresholdY = (int) (screenHeight * 0.75);
         }
 
-        // Only toggle if the tap occurred in the bottom region
         if (tapY >= thresholdY) {
-            // Existing toggle logic
             View blackOverlay = findViewById(R.id.black);
 
             if (gifHeader != null && blackOverlay != null) {
@@ -1284,10 +1274,10 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                     AnimatorUtil.fadeIn(blackOverlay);
                     getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
                 }
-                return true; // Indicate that the event was handled
+                return true;
             }
         }
-        return false; // Indicate that the event was not handled
+        return false;
     }
 
     @Override

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -686,13 +686,11 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                             didLoadGif = true; // Mark that a GIF was successfully loaded this way
                             fileLoc = gifFile.getAbsolutePath(); // Potentially for cleanup, though this might need review
 
-                            // Add OnClickListener for directGifViewer (direct GIFs)
                             directGifViewer.setOnClickListener(new View.OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
-                                    // Simulate a tap in the bottom quarter of the screen to ensure it passes the thresholdY check
                                     int screenHeight = getResources().getDisplayMetrics().heightPixels;
-                                    float simulatedTapY = screenHeight * 0.8f; // 80% down the screen
+                                    float simulatedTapY = screenHeight * 0.8f;
 
                                     MotionEvent motionEvent = MotionEvent.obtain(
                                             SystemClock.uptimeMillis(),

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -1247,7 +1247,7 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
     }
 
     @Override
-    public void onSingleTap(MotionEvent event) {
+    public boolean onSingleTap(MotionEvent event) {
         // Get screen height and the Y-coordinate of the tap
         int screenHeight = getResources().getDisplayMetrics().heightPixels;
         float tapY = event.getRawY(); // Use getRawY for screen coordinates
@@ -1284,8 +1284,10 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                     AnimatorUtil.fadeIn(blackOverlay);
                     getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
                 }
+                return true; // Indicate that the event was handled
             }
         }
+        return false; // Indicate that the event was not handled
     }
 
     @Override

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -584,6 +584,25 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
         }
 
         hideOnLongClick();
+
+        findViewById(R.id.black).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                int screenHeight = getResources().getDisplayMetrics().heightPixels;
+                float simulatedTapY = screenHeight * 0.5f;
+
+                MotionEvent motionEvent = MotionEvent.obtain(
+                        SystemClock.uptimeMillis(),
+                        SystemClock.uptimeMillis() + 100,
+                        MotionEvent.ACTION_UP,
+                        0,
+                        simulatedTapY,
+                        0
+                );
+                onSingleTap(motionEvent);
+                motionEvent.recycle();
+            }
+        });
     }
 
     public void doLoad(final String contentUrl) {
@@ -1037,6 +1056,25 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                 (findViewById(R.id.progress)).setVisibility(View.GONE);
                 handler.removeCallbacks(progressBarDelayRunner);
 
+                i.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        int screenHeight = getResources().getDisplayMetrics().heightPixels;
+                        float simulatedTapY = screenHeight * 0.8f;
+
+                        MotionEvent motionEvent = MotionEvent.obtain(
+                                SystemClock.uptimeMillis(),
+                                SystemClock.uptimeMillis() + 100,
+                                MotionEvent.ACTION_UP,
+                                0,
+                                simulatedTapY,
+                                0
+                        );
+                        onSingleTap(motionEvent);
+                        motionEvent.recycle();
+                    }
+                });
+
                 previous = i.scale;
                 final float base = i.scale;
                 i.postDelayed(
@@ -1149,6 +1187,25 @@ public class MediaView extends BaseSaveActivity implements ExoVideoView.OnSingle
                                         }
                                         (findViewById(R.id.progress)).setVisibility(View.GONE);
                                         handler.removeCallbacks(progressBarDelayRunner);
+
+                                        i.setOnClickListener(new View.OnClickListener() {
+                                            @Override
+                                            public void onClick(View v) {
+                                                int screenHeight = getResources().getDisplayMetrics().heightPixels;
+                                                float simulatedTapY = screenHeight * 0.8f;
+
+                                                MotionEvent motionEvent = MotionEvent.obtain(
+                                                        SystemClock.uptimeMillis(),
+                                                        SystemClock.uptimeMillis() + 100,
+                                                        MotionEvent.ACTION_UP,
+                                                        0,
+                                                        simulatedTapY,
+                                                        0
+                                                );
+                                                onSingleTap(motionEvent);
+                                                motionEvent.recycle();
+                                            }
+                                        });
 
                                         previous = i.scale;
                                         final float base = i.scale;

--- a/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/MediaView.java
@@ -604,7 +604,8 @@ public class MediaView extends BaseSaveActivity {
                             public void onClick(View v) {
                                 if (findViewById(R.id.gifheader).getVisibility() == View.GONE) {
                                     AnimatorUtil.animateIn(findViewById(R.id.gifheader), 56);
-                                    AnimatorUtil.fadeOut(findViewById(R.id.black));
+                                    View blackOverlay = findViewById(R.id.black);
+                                    AnimatorUtil.fadeOut(blackOverlay, () -> blackOverlay.setVisibility(View.GONE));
                                 }
                             }
                         });

--- a/app/src/main/java/me/edgan/redditslide/Activities/RedditGalleryPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/RedditGalleryPager.java
@@ -371,7 +371,7 @@ public class RedditGalleryPager extends BaseSaveActivity implements GalleryParen
         if (!isGif) {
             bottomSheetBuilder.sheet(3, image, getString(R.string.share_image));
         }
-        bottomSheetBuilder.sheet(4, save, getString(R.string.submission_save_image));
+        bottomSheetBuilder.sheet(4, save, getString(isGif ? R.string.submission_save_mp4 : R.string.submission_save_image));
 
         bottomSheetBuilder.listener(
                 (dialog, which) -> {

--- a/app/src/main/java/me/edgan/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/TumblrPager.java
@@ -536,6 +536,14 @@ public class TumblrPager extends BaseSaveActivity {
                                     }
                                 }
                             });
+            View mute = rootView.findViewById(R.id.mute);
+            if (mute != null) {
+                mute.setVisibility(View.GONE);
+            }
+            View hq = rootView.findViewById(R.id.hq);
+            if (hq != null) {
+                hq.setVisibility(View.GONE);
+            }
             return rootView;
         }
 
@@ -760,6 +768,14 @@ public class TumblrPager extends BaseSaveActivity {
                                 });
             } else {
                 rootView.findViewById(R.id.comments).setVisibility(View.GONE);
+            }
+            View mute = rootView.findViewById(R.id.mute);
+            if (mute != null) {
+                mute.setVisibility(View.GONE);
+            }
+            View hq = rootView.findViewById(R.id.hq);
+            if (hq != null) {
+                hq.setVisibility(View.GONE);
             }
             return rootView;
         }

--- a/app/src/main/java/me/edgan/redditslide/Activities/TumblrPager.java
+++ b/app/src/main/java/me/edgan/redditslide/Activities/TumblrPager.java
@@ -568,7 +568,7 @@ public class TumblrPager extends BaseSaveActivity {
         b.sheet(2, external, getString(R.string.open_externally));
         b.sheet(5, share, getString(R.string.submission_link_share));
         if (!isGif) b.sheet(3, image, getString(R.string.share_image));
-        b.sheet(4, save, getString(R.string.submission_save_image));
+        b.sheet(4, save, getString(isGif ? R.string.submission_save_mp4 : R.string.submission_save_image));
         b.listener(
                 new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -57,6 +57,15 @@ import me.edgan.redditslide.util.NetworkUtil;
 public class ExoVideoView extends RelativeLayout {
     private static final String TAG = "ExoVideoView";
 
+    public interface OnSingleTapListener {
+        void onSingleTap();
+    }
+    private OnSingleTapListener singleTapListener;
+
+    public void setOnSingleTapListener(OnSingleTapListener listener) {
+        this.singleTapListener = listener;
+    }
+
     private Context context;
     private SimpleExoPlayer player;
     private DefaultTrackSelector trackSelector;
@@ -869,6 +878,12 @@ public class ExoVideoView extends RelativeLayout {
             }
         } // end if (scaleFactor > 1.0f && !scalingInProgress)
 
+        // Detect single tap and notify listener
+        if (action == MotionEvent.ACTION_UP && !wasScaling && !wasDragging && !scalingInProgress) {
+            if (singleTapListener != null) {
+                singleTapListener.onSingleTap();
+            }
+        }
 
         // Determine if the event should be consumed (preventing click)
         // Consume if:

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -878,12 +878,11 @@ public class ExoVideoView extends RelativeLayout {
             }
         } // end if (scaleFactor > 1.0f && !scalingInProgress)
 
-        // Detect single tap and notify listener
         if (action == MotionEvent.ACTION_UP && !wasScaling && !wasDragging && !scalingInProgress) {
             if (singleTapListener != null) {
                 boolean handled = singleTapListener.onSingleTap(event);
                 if (handled) {
-                    return true; // Consume the event if it was handled
+                    return true;
                 }
             }
         }

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -58,7 +58,7 @@ public class ExoVideoView extends RelativeLayout {
     private static final String TAG = "ExoVideoView";
 
     public interface OnSingleTapListener {
-        void onSingleTap();
+        void onSingleTap(MotionEvent event);
     }
     private OnSingleTapListener singleTapListener;
 
@@ -881,7 +881,7 @@ public class ExoVideoView extends RelativeLayout {
         // Detect single tap and notify listener
         if (action == MotionEvent.ACTION_UP && !wasScaling && !wasDragging && !scalingInProgress) {
             if (singleTapListener != null) {
-                singleTapListener.onSingleTap();
+                singleTapListener.onSingleTap(event);
             }
         }
 

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -334,29 +334,26 @@ public class ExoVideoView extends RelativeLayout {
             }
         };
 
-        if (videoFrame != null) {
-            videoFrame.setClickable(true);
-            videoFrame.setOnClickListener((v) -> {
-                // Ensure playerUI, player, and handler are not null
-                if (playerUI == null || player == null || handler == null) return;
+        setOnClickListener((v) -> {
+            // Ensure playerUI, player, and handler are not null
+            if (playerUI == null || player == null || handler == null) return;
 
-                // Always remove pending runnable when screen is tapped
-                handler.removeCallbacks(hideControlsRunnable);
+            // Always remove pending runnable when screen is tapped
+            handler.removeCallbacks(hideControlsRunnable);
 
-                if (playerUI.isVisible()) {
-                    // If visible, just hide.
-                    playerUI.hide();
-                } else {
-                    // If hidden, show and decide whether to schedule auto-hide.
-                    playerUI.show();
-                    boolean isPlaying = player.getPlayWhenReady();
-                    if (isPlaying) {
-                        // If playing, schedule the hide runnable.
-                        handler.postDelayed(hideControlsRunnable, 2000);
-                    }
+            if (playerUI.isVisible()) {
+                // If visible, just hide.
+                playerUI.hide();
+            } else {
+                // If hidden, show and decide whether to schedule auto-hide.
+                playerUI.show();
+                boolean isPlaying = player.getPlayWhenReady();
+                if (isPlaying) {
+                    // If playing, schedule the hide runnable.
+                    handler.postDelayed(hideControlsRunnable, 2000);
                 }
-            });
-        }
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -58,7 +58,7 @@ public class ExoVideoView extends RelativeLayout {
     private static final String TAG = "ExoVideoView";
 
     public interface OnSingleTapListener {
-        void onSingleTap(MotionEvent event);
+        boolean onSingleTap(MotionEvent event);
     }
     private OnSingleTapListener singleTapListener;
 
@@ -881,7 +881,10 @@ public class ExoVideoView extends RelativeLayout {
         // Detect single tap and notify listener
         if (action == MotionEvent.ACTION_UP && !wasScaling && !wasDragging && !scalingInProgress) {
             if (singleTapListener != null) {
-                singleTapListener.onSingleTap(event);
+                boolean handled = singleTapListener.onSingleTap(event);
+                if (handled) {
+                    return true; // Consume the event if it was handled
+                }
             }
         }
 

--- a/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
+++ b/app/src/main/java/me/edgan/redditslide/Views/ExoVideoView.java
@@ -331,26 +331,29 @@ public class ExoVideoView extends RelativeLayout {
             }
         };
 
-        setOnClickListener((v) -> {
-            // Ensure playerUI, player, and handler are not null
-            if (playerUI == null || player == null || handler == null) return;
+        if (videoFrame != null) {
+            videoFrame.setClickable(true);
+            videoFrame.setOnClickListener((v) -> {
+                // Ensure playerUI, player, and handler are not null
+                if (playerUI == null || player == null || handler == null) return;
 
-            // Always remove pending runnable when screen is tapped
-            handler.removeCallbacks(hideControlsRunnable);
+                // Always remove pending runnable when screen is tapped
+                handler.removeCallbacks(hideControlsRunnable);
 
-            if (playerUI.isVisible()) {
-                // If visible, just hide.
-                playerUI.hide();
-            } else {
-                // If hidden, show and decide whether to schedule auto-hide.
-                playerUI.show();
-                boolean isPlaying = player.getPlayWhenReady();
-                if (isPlaying) {
-                    // If playing, schedule the hide runnable.
-                    handler.postDelayed(hideControlsRunnable, 2000);
+                if (playerUI.isVisible()) {
+                    // If visible, just hide.
+                    playerUI.hide();
+                } else {
+                    // If hidden, show and decide whether to schedule auto-hide.
+                    playerUI.show();
+                    boolean isPlaying = player.getPlayWhenReady();
+                    if (isPlaying) {
+                        // If playing, schedule the hide runnable.
+                        handler.postDelayed(hideControlsRunnable, 2000);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     /**

--- a/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
@@ -62,13 +62,6 @@ public class AnimatorUtil {
     public static void animateIn(final View view, final int dp) {
         view.setVisibility(View.VISIBLE);
         final ValueAnimator mAnimator = slideAnimator(0, DisplayUtil.dpToPxVertical(dp), view);
-        mAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                view.requestLayout();
-                view.invalidate();
-            }
-        });
         mAnimator.start();
     }
 

--- a/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
@@ -62,6 +62,13 @@ public class AnimatorUtil {
     public static void animateIn(final View view, final int dp) {
         view.setVisibility(View.VISIBLE);
         final ValueAnimator mAnimator = slideAnimator(0, DisplayUtil.dpToPxVertical(dp), view);
+        mAnimator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                view.requestLayout();
+                view.invalidate();
+            }
+        });
         mAnimator.start();
     }
 

--- a/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
@@ -71,24 +71,11 @@ public class AnimatorUtil {
     }
 
     public static void fadeOut(final View view) {
-        fadeOut(view, () -> view.setVisibility(View.GONE));
-    }
-
-    public static void fadeOut(final View view, final Runnable onEndAction) {
-        final ValueAnimator mAnimator = fadeAnimator(1, 0f, view); // Fade to fully transparent
-        mAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                if (onEndAction != null) {
-                    onEndAction.run();
-                }
-            }
-        });
+        final ValueAnimator mAnimator = fadeAnimator(1, .66f, view);
         mAnimator.start();
     }
 
     public static ValueAnimator fadeAnimator(final float start, final float end, final View view) {
-        view.setVisibility(View.VISIBLE); // Ensure view is visible before fading
         final ValueAnimator animator = ValueAnimator.ofFloat(start, end);
         animator.setInterpolator(new FastOutSlowInInterpolator());
         // Update height

--- a/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/AnimatorUtil.java
@@ -71,11 +71,24 @@ public class AnimatorUtil {
     }
 
     public static void fadeOut(final View view) {
-        final ValueAnimator mAnimator = fadeAnimator(1, .66f, view);
+        fadeOut(view, () -> view.setVisibility(View.GONE));
+    }
+
+    public static void fadeOut(final View view, final Runnable onEndAction) {
+        final ValueAnimator mAnimator = fadeAnimator(1, 0f, view); // Fade to fully transparent
+        mAnimator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if (onEndAction != null) {
+                    onEndAction.run();
+                }
+            }
+        });
         mAnimator.start();
     }
 
     public static ValueAnimator fadeAnimator(final float start, final float end, final View view) {
+        view.setVisibility(View.VISIBLE); // Ensure view is visible before fading
         final ValueAnimator animator = ValueAnimator.ofFloat(start, end);
         animator.setInterpolator(new FastOutSlowInInterpolator());
         // Update height

--- a/app/src/main/java/me/edgan/redditslide/util/DisplayUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/DisplayUtil.java
@@ -1,7 +1,6 @@
 package me.edgan.redditslide.util;
 
 import android.content.res.Resources;
-import android.util.DisplayMetrics;
 
 /** Created by TacoTheDank on 03/15/2021. */
 public class DisplayUtil {

--- a/app/src/main/java/me/edgan/redditslide/util/DisplayUtil.java
+++ b/app/src/main/java/me/edgan/redditslide/util/DisplayUtil.java
@@ -6,7 +6,7 @@ import android.util.DisplayMetrics;
 /** Created by TacoTheDank on 03/15/2021. */
 public class DisplayUtil {
     private static int dpToPx(int dp, float xy) {
-        return Math.round(dp * xy / DisplayMetrics.DENSITY_DEFAULT);
+        return Math.round(dp * Resources.getSystem().getDisplayMetrics().density);
     }
 
     public static int dpToPxVertical(int dp) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="submission_gild">Open in browser</string>
     <string name="submission_save">Save post</string>
     <string name="submission_save_image">Save image</string>
+    <string name="submission_save_mp4">Save MP4</string>
     <string name="submission_load_full">Load full thread</string>
     <string name="submission_np_link">This is a no participation link. Please don\'t vote or comment.</string>
     <string name="submission_tap_gif">Tap to load GIF</string>


### PR DESCRIPTION
This PR significantly improves video control behavior and streamlines media saving options.
- Restores single tap functionality to fully toggle video controls in ExoVideoView, allowing them to reappear after being hidden, with refined tap zone logic. #251 
- Removes a redundant save GIF button. #252 
- Standardizes media saving prompts, renaming "Save Image" to "Save MP4" for GIFs/Videos across all relevant pagers (AlbumPager, RedditGalleryPager, TumblrPager) #253 
- Resolve incorrect DP to pixel conversion for bottom control icons #255 
- Hide non-functional mute and HQ buttons in TumblrPager #256 