### PR TITLE
Fix Crash: NullPointerException when entering Special Tabs with "Hide subscribed subreddit tabs" enabled 

### DIFF
--- a/app/src/main/java/me/edgan/redditslide/Adapters/SideArrayAdapter.java
+++ b/app/src/main/java/me/edgan/redditslide/Adapters/SideArrayAdapter.java
@@ -203,7 +203,9 @@ public class SideArrayAdapter extends ArrayAdapter<String> {
                                         int pos = mainActivity.usedArray.indexOf(subreddit);
                                         mainActivity.pager.setCurrentItem(pos);
                                         mainActivity.drawerLayout.closeDrawers();
-                                        ((MainActivity) getContext()).drawerSearch.setText("");
+                                        if (((MainActivity) getContext()).drawerSearch != null) {
+                                            ((MainActivity) getContext()).drawerSearch.setText("");
+                                        }
                                     } else if (subreddit.equalsIgnoreCase("random")
                                                 || subreddit.equalsIgnoreCase("randnsfw")
                                                 || subreddit.equalsIgnoreCase("myrandom")) {


### PR DESCRIPTION
This addresses a crash (#247) encountered when accessing specific tabs (frontpage, all, m/tabs) via the sidebar or toolbar. 